### PR TITLE
Allow to unset the `defaultChoice` for confirm-input

### DIFF
--- a/source/components/confirm-input/confirm-input.tsx
+++ b/source/components/confirm-input/confirm-input.tsx
@@ -16,7 +16,7 @@ export type ConfirmInputProps = {
 	 *
 	 * @default "confirm"
 	 */
-	defaultChoice?: 'confirm' | 'cancel';
+	defaultChoice?: 'confirm' | 'cancel' | 'unset';
 
 	/**
 	 * Confirm or cancel when user presses enter, depending on the `defaultChoice` value.
@@ -44,6 +44,12 @@ export function ConfirmInput({
 	onConfirm,
 	onCancel,
 }: ConfirmInputProps) {
+	const choicePrompts = {
+		confirm: 'Y/n',
+		cancel: 'y/N',
+		unset: 'y/n',
+	};
+
 	useInput(
 		(input, key) => {
 			if (input.toLowerCase() === 'y') {
@@ -55,10 +61,20 @@ export function ConfirmInput({
 			}
 
 			if (key.return && submitOnEnter) {
-				if (defaultChoice === 'confirm') {
-					onConfirm();
-				} else {
-					onCancel();
+				switch (defaultChoice) {
+					case 'confirm': {
+						onConfirm();
+						break;
+					}
+
+					case 'cancel': {
+						onCancel();
+						break;
+					}
+
+					default: {
+						break;
+					}
 				}
 			}
 		},
@@ -69,7 +85,7 @@ export function ConfirmInput({
 
 	return (
 		<Text {...styles.input({isFocused: !isDisabled})}>
-			{defaultChoice === 'confirm' ? 'Y/n' : 'y/N'}
+			{choicePrompts[defaultChoice]}
 		</Text>
 	);
 }

--- a/test/confirm-input.tsx
+++ b/test/confirm-input.tsx
@@ -223,3 +223,69 @@ test('cancel with disabled enter', async t => {
 	t.false(confirmed);
 	t.true(cancelled);
 });
+
+test('unset the default choice, confirm via "y"', async t => {
+	let confirmed = false;
+	let cancelled = false;
+
+	const {lastFrame, stdin} = render(
+		<ConfirmInput
+			defaultChoice="unset"
+			onConfirm={() => {
+				confirmed = true;
+			}}
+			onCancel={() => {
+				cancelled = true;
+			}}
+		/>,
+	);
+
+	t.is(lastFrame(), 'y/n');
+
+	await delay(50);
+	stdin.write(enter);
+	await delay(50);
+
+	t.false(confirmed);
+	t.false(cancelled);
+
+	await delay(50);
+	stdin.write('y');
+	await delay(50);
+
+	t.true(confirmed);
+	t.false(cancelled);
+});
+
+test('unset the default choice, cancle via "n"', async t => {
+	let confirmed = false;
+	let cancelled = false;
+
+	const {lastFrame, stdin} = render(
+		<ConfirmInput
+			defaultChoice="unset"
+			onConfirm={() => {
+				confirmed = true;
+			}}
+			onCancel={() => {
+				cancelled = true;
+			}}
+		/>,
+	);
+
+	t.is(lastFrame(), 'y/n');
+
+	await delay(50);
+	stdin.write(enter);
+	await delay(50);
+
+	t.false(confirmed);
+	t.false(cancelled);
+
+	await delay(50);
+	stdin.write('n');
+	await delay(50);
+
+	t.false(confirmed);
+	t.true(cancelled);
+});


### PR DESCRIPTION
This allows user to unset the `defaultChoice`.

Nothing will happen when the user simply presses enter with `defaultChoice="unset"`.