### PR TITLE
elimiuate ts warning for test folder, working under WebStorm

### DIFF
--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.json",
+	"include": ["."]
+}


### PR DESCRIPTION
WebStorm always shows red mark if open any test file for editing. This patch learns it not to mark.