### PR TITLE
elimiuate ts warning for examples folder, working under WebStorm

### DIFF
--- a/examples/autocomplete.tsx
+++ b/examples/autocomplete.tsx
@@ -51,7 +51,7 @@ function Example() {
 					<TextInput onChange={setFilterText} />
 
 					<Select
-						defaultLimit={5}
+						visibleOptionCount={3}
 						highlightText={filterText}
 						options={options}
 						onChange={setValue}

--- a/examples/theming/custom-component.tsx
+++ b/examples/theming/custom-component.tsx
@@ -1,4 +1,5 @@
-import React, {render, Text, type TextProps} from 'ink';
+import React from 'react';
+import {render, Text, type TextProps} from 'ink';
 import {
 	ThemeProvider,
 	defaultTheme,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.json",
+	"include": ["."]
+}


### PR DESCRIPTION

WebStorm always shows red mark if open any **examples** file for editing. This patch learns it not to mark.