### PR TITLE
Upgrade ink peer dependency to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"eslint-config-xo-react": "^0.27.0",
 		"eslint-plugin-react": "^7.34.1",
 		"eslint-plugin-react-hooks": "^4.6.2",
-		"ink": "^5.0.0",
+		"ink": "^6.0.0",
 		"ink-testing-library": "^4.0.0",
 		"prettier": "^3.2.5",
 		"react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"xo": "^0.58.0"
 	},
 	"peerDependencies": {
-		"ink": ">=5"
+		"ink": ">=6"
 	},
 	"ava": {
 		"extensions": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"ink": "^6.0.0",
 		"ink-testing-library": "^4.0.0",
 		"prettier": "^3.2.5",
-		"react": "^18.3.1",
+		"react": "^19.0.0",
 		"tsimp": "^2.0.11",
 		"typescript": "^5.4.5",
 		"xo": "^0.58.0"


### PR DESCRIPTION
I hope I'm not missing anything but I manually tested all components and ran all tests and it looks like it'd be as simple as that. I guess ink is doing the heavy lifting here.

Closes #14 