### PR TITLE
Add IME cursor positioning support to TextInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"cli-spinners": "^3.0.0",
 		"deepmerge": "^4.3.1",
 		"figures": "^6.1.0",
-		"string-width": "^7.0.0"
+		"string-width": "^8.1.1"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"chalk": "^5.3.0",
 		"cli-spinners": "^3.0.0",
 		"deepmerge": "^4.3.1",
-		"figures": "^6.1.0"
+		"figures": "^6.1.0",
+		"string-width": "^7.0.0"
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^5.0.0",
@@ -47,7 +48,7 @@
 		"eslint-config-xo-react": "^0.27.0",
 		"eslint-plugin-react": "^7.34.1",
 		"eslint-plugin-react-hooks": "^4.6.2",
-		"ink": "^5.0.0",
+		"ink": "^6.7.0",
 		"ink-testing-library": "^4.0.0",
 		"prettier": "^3.2.5",
 		"react": "^18.3.1",
@@ -56,7 +57,7 @@
 		"xo": "^0.58.0"
 	},
 	"peerDependencies": {
-		"ink": ">=5"
+		"ink": ">=6.7.0"
 	},
 	"ava": {
 		"extensions": {

--- a/source/components/text-input/text-input.tsx
+++ b/source/components/text-input/text-input.tsx
@@ -37,6 +37,14 @@ export type TextInputProps = {
 	 * Callback when enter is pressed. First argument is input value.
 	 */
 	readonly onSubmit?: (value: string) => void;
+
+	/**
+	 * Row position of the text input relative to Ink's output origin.
+	 * Used to position the real terminal cursor for IME (Input Method Editor) support.
+	 * When set, CJK (Korean, Japanese, Chinese) composition windows appear
+	 * at the correct position instead of the bottom-left corner.
+	 */
+	readonly cursorRow?: number;
 };
 
 export function TextInput({
@@ -46,6 +54,7 @@ export function TextInput({
 	suggestions,
 	onChange,
 	onSubmit,
+	cursorRow,
 }: TextInputProps) {
 	const state = useTextInputState({
 		defaultValue,
@@ -58,6 +67,7 @@ export function TextInput({
 		isDisabled,
 		placeholder,
 		state,
+		cursorRow,
 	});
 
 	const {styles} = useComponentTheme<Theme>('TextInput');

--- a/source/components/text-input/text-input.tsx
+++ b/source/components/text-input/text-input.tsx
@@ -39,12 +39,16 @@ export type TextInputProps = {
 	readonly onSubmit?: (value: string) => void;
 
 	/**
-	 * Row position of the text input relative to Ink's output origin.
+	 * Starting position of the text input relative to Ink's output origin.
 	 * Used to position the real terminal cursor for IME (Input Method Editor) support.
 	 * When set, CJK (Korean, Japanese, Chinese) composition windows appear
 	 * at the correct position instead of the bottom-left corner.
+	 *
+	 * - `y` (required): row where the text input is rendered.
+	 * - `x` (optional, default `0`): column where the text starts, useful when
+	 *   there is a label or prompt rendered before the input on the same line.
 	 */
-	readonly cursorRow?: number;
+	readonly cursorStart?: {readonly x?: number; readonly y: number};
 };
 
 export function TextInput({
@@ -54,7 +58,7 @@ export function TextInput({
 	suggestions,
 	onChange,
 	onSubmit,
-	cursorRow,
+	cursorStart,
 }: TextInputProps) {
 	const state = useTextInputState({
 		defaultValue,
@@ -67,7 +71,7 @@ export function TextInput({
 		isDisabled,
 		placeholder,
 		state,
-		cursorRow,
+		cursorStart,
 	});
 
 	const {styles} = useComponentTheme<Theme>('TextInput');

--- a/source/components/text-input/use-text-input.ts
+++ b/source/components/text-input/use-text-input.ts
@@ -23,12 +23,16 @@ export type UseTextInputProps = {
 	placeholder?: string;
 
 	/**
-	 * Row position of the text input relative to Ink's output origin.
+	 * Starting position of the text input relative to Ink's output origin.
 	 * Used to position the real terminal cursor for IME (Input Method Editor) support.
 	 * When set, CJK (Korean, Japanese, Chinese) composition windows appear
 	 * at the correct position instead of the bottom-left corner.
+	 *
+	 * - `y` (required): row where the text input is rendered.
+	 * - `x` (optional, default `0`): column where the text starts, useful when
+	 *   there is a label or prompt rendered before the input on the same line.
 	 */
-	cursorRow?: number;
+	cursorStart?: {readonly x?: number; readonly y: number};
 };
 
 export type UseTextInputResult = {
@@ -44,15 +48,18 @@ export const useTextInput = ({
 	isDisabled = false,
 	state,
 	placeholder = '',
-	cursorRow,
+	cursorStart,
 }: UseTextInputProps): UseTextInputResult => {
 	const {setCursorPosition} = useCursor();
 
 	// Position the real terminal cursor for IME composition support.
 	// This allows CJK input method windows to appear at the correct location.
-	if (!isDisabled && cursorRow !== undefined) {
+	if (!isDisabled && cursorStart !== undefined) {
 		const textBeforeCursor = state.value.slice(0, state.cursorOffset);
-		setCursorPosition({x: stringWidth(textBeforeCursor), y: cursorRow});
+		setCursorPosition({
+			x: (cursorStart.x ?? 0) + stringWidth(textBeforeCursor),
+			y: cursorStart.y,
+		});
 	} else {
 		setCursorPosition(undefined);
 	}

--- a/source/components/text-input/use-text-input.ts
+++ b/source/components/text-input/use-text-input.ts
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
-import {useInput} from 'ink';
+import {useInput, useCursor} from 'ink';
 import chalk from 'chalk';
+import stringWidth from 'string-width';
 import {type TextInputState} from './use-text-input-state.js';
 
 export type UseTextInputProps = {
@@ -20,6 +21,14 @@ export type UseTextInputProps = {
 	 * Text to display when input is empty.
 	 */
 	placeholder?: string;
+
+	/**
+	 * Row position of the text input relative to Ink's output origin.
+	 * Used to position the real terminal cursor for IME (Input Method Editor) support.
+	 * When set, CJK (Korean, Japanese, Chinese) composition windows appear
+	 * at the correct position instead of the bottom-left corner.
+	 */
+	cursorRow?: number;
 };
 
 export type UseTextInputResult = {
@@ -35,7 +44,19 @@ export const useTextInput = ({
 	isDisabled = false,
 	state,
 	placeholder = '',
+	cursorRow,
 }: UseTextInputProps): UseTextInputResult => {
+	const {setCursorPosition} = useCursor();
+
+	// Position the real terminal cursor for IME composition support.
+	// This allows CJK input method windows to appear at the correct location.
+	if (!isDisabled && cursorRow !== undefined) {
+		const textBeforeCursor = state.value.slice(0, state.cursorOffset);
+		setCursorPosition({x: stringWidth(textBeforeCursor), y: cursorRow});
+	} else {
+		setCursorPosition(undefined);
+	}
+
 	const renderedPlaceholder = useMemo(() => {
 		if (isDisabled) {
 			return placeholder ? chalk.dim(placeholder) : '';


### PR DESCRIPTION
Closes #18

Add optional `cursorStart` prop to `TextInput` that positions the real terminal cursor for IME composition support. When set, CJK (Korean, Japanese, Chinese) input method windows appear at the correct cursor position instead of the terminal's bottom-left corner.

Uses `useCursor` from ink 6.7.0 ([ink#866](https://github.com/vadimdemedes/ink/pull/866)) to move the real terminal cursor to the computed coordinates.

### API

```tsx
<TextInput
  cursorStart={{ x: promptWidth, y: rowIndex }}
  // ...
/>
```

- `y` (required): row where the text input is rendered
- `x` (optional, default `0`): column where the text starts, useful when there is a label or prompt rendered before the input on the same line

### Changes

- `text-input.tsx`: Add `cursorStart?: {readonly x?: number; readonly y: number}` prop, pass through to `useTextInput`
- `use-text-input.ts`: Import `useCursor` from ink and `stringWidth` from string-width; call `setCursorPosition({x, y})` when enabled, reset to `undefined` when disabled
- `package.json`: Bump `string-width` to `^8.1.1` (matches ink 6.7.0), bump ink peer/dev dependency to `>=6.7.0`

### Breaking change

- Peer dependency on ink changed from `>=5` to `>=6.7.0` (requires `useCursor` API)
- Note: PR #15 already proposes upgrading the ink peer dep to v6

### Test plan

- Tested locally with `ink@6.7.0` on macOS with Korean (2-set) and Japanese input methods
- IME composition window appears at the cursor position instead of bottom-left
- Backward compatible when `cursorStart` is omitted
- Demos: [subinium/korean-terminal](https://github.com/subinium/korean-terminal)